### PR TITLE
Update Spin build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,14 @@ This will launch a webservice and an x-server.  The webservice will use port 155
 docker run -p 1555:80 -v <your_pgdbs_folder>:/pathway_tools/aic_export/pgdbs/ -t <container_tag>
 ```
 
+# To run on Spin:
+
+First, tag the image for the Spin registry, then push it. You may need to log into the registry first:
+
+```
+docker login registry.spin.nersc.gov
+docker tag pathway:21.0 registry.spin.nersc.gov/wildish/pathway:21.0
+docker push registry.spin.nersc.gov/wildish/pathway:21.0
+```
+
+You can create a stack in Spin using the *docker-compose.yml* file in this repository. Ask Cory Snavely and the Spin team for help with that.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '2'
+services:
+  pathway:
+    image: registry.spin.nersc.gov/wildish/pathway:21.0
+    stdin_open: true
+    tty: true
+    ports:
+    - 8080:1555/tcp
+    labels:
+      io.rancher.container.pull_image: always
+

--- a/rancher-compose.yml
+++ b/rancher-compose.yml
@@ -1,0 +1,6 @@
+version: '2'
+services:
+  pathway:
+    scale: 1
+    start_on_create: true
+


### PR DESCRIPTION
I've updated the instructions for building/deploying on Spin, and saved the docker-compose and rancher-compose files to the repository. So it should be easy to re-create the stack if it ever gets lost again.